### PR TITLE
cfg: add architecture label to ec2 instances

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -29,6 +29,7 @@ resource "aws_instance" "this" {
   tags = merge(
     var.tags,
     tomap({ "Name" = format("%s-%s-bck-storage0%s-0%s", var.environment, var.project, var.shard_id, count.index + var.index_offset + 1) }),
+    tomap({ "architecture" = var.instance_architecture }),
   )
 
   lifecycle {

--- a/variables.tf
+++ b/variables.tf
@@ -76,6 +76,12 @@ variable "instance_type" {
   description = "AWS EC2 instance type"
 }
 
+variable "instance_architecture" {
+  type        = string
+  default     = "x86_64"
+  description = "AWS EC2 instance processor architecture"
+}
+
 variable "root_volume_size" {
   type        = string
   default     = "50"


### PR DESCRIPTION
- Adds the architecture tag to avoid a drift with the current platform.

/kind feature
/priority important-soon
/assign